### PR TITLE
Update github runner to ubuntu-latest

### DIFF
--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -5,7 +5,7 @@ on: push
 jobs:
   build-n-publish:
     name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
       - name: Set up Python 3.8


### PR DESCRIPTION
Previous workflow execution timed out waiting for github runner due to deprecated tag (`ubuntu-20.04`). This commit sets that tag to `ubuntu-latest` which is supported and should not require update in the future.